### PR TITLE
Uncommented the correct line in src/topics/create.js for failing test case Issue #26

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -56,7 +56,7 @@ module.exports = function (Topics) {
 			'topics:tid',
 			`cid:${topicData.cid}:tids`,
 			`cid:${topicData.cid}:tids:create`,
-			// `cid:${topicData.cid}:uid:${topicData.uid}:tids`,
+			`cid:${topicData.cid}:uid:${topicData.uid}:tids`,
 			// commented out to prevent the creation of a tag for anonymous users
 		];
 

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -41,8 +41,8 @@ module.exports = function (Topics) {
 			user.displayname = 'Anonymous';
 		}
 		// this line is to see console output
-		console.log('Incoming data:', data);
-		console.log('Topic data to be saved:', topicData);
+		// console.log('Incoming data:', data);
+		// console.log('Topic data to be saved:', topicData);
 
 		if (Array.isArray(data.tags) && data.tags.length) {
 			topicData.tags = data.tags.join(',');


### PR DESCRIPTION
Hello,

This commit fixes the NPM Test error we were getting in Issue https://github.com/CMU-313/nodebb-f24-team-craig-street-chipotle/issues/26

Categories
api/socket methods
should load more topics:
Uncaught TypeError: Cannot read properties of undefined (reading 'user')
at /home/runner/work/nodebb-f24-team-craig-street-chipotle/nodebb-f24-team-craig-street-chipotle/test/categories.js:233:33
at /home/runner/work/nodebb-f24-team-craig-street-chipotle/nodebb-f24-team-craig-street-chipotle/src/promisify.js:2:2441
at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Line 59 in src/topics/create.js was removed initially as it referenced the username and that was not wanted when working on anonymous.

But, this line is explicitly mentioned in the test cases, thus when the test case called to this line user remained undefined since it was commented out. Now with the line back in the does not occur. The other additions are small pieces that were added back or removed in trying to solve this testing error.